### PR TITLE
Add Vanilla Sugar perfume and remove quiz fragrance list

### DIFF
--- a/mixer-final-100-main/client/data/perfume-links.ts
+++ b/mixer-final-100-main/client/data/perfume-links.ts
@@ -31,6 +31,11 @@ export const perfumeLinks: PerfumeLink[] = [
     perfumeId: "rose-vanille",
     buyUrl: "https://golden-aroma.square.site/product/inspired-by-rose-vanille-rose-vanilla/T6JVCELFAGDSDFHIQRGPCAJU?cp=true&sa=false&sbp=false&q=false&category_id=2GCWNDMHNSKSAA2K76ASX36N",
   },
+  {
+    perfumeId: "vanilla-sugar",
+    buyUrl:
+      "https://golden-aroma.square.site/product/inspired-by-vanilla-rock-sugar-vanilla-sugar/HFB7M2LQJFOEMB4TEEAJCBMD?cp=true&sa=false&sbp=false&q=true",
+  },
   { perfumeId: "red-tobacco", buyUrl: "https://golden-aroma.square.site/product/inspired-by-red-tobacco-red-tobacco-flame/W6RHZX74QVQTWZQI4ELTNJ5Y?cp=true&sa=false&sbp=false&q=false&category_id=2GCWNDMHNSKSAA2K76ASX36N" },
   {
     perfumeId: "imagination-lv",

--- a/mixer-final-100-main/client/data/perfumes.ts
+++ b/mixer-final-100-main/client/data/perfumes.ts
@@ -202,6 +202,33 @@ export const perfumes: Perfume[] = [
     sizes: standardSizes,
   },
   {
+    id: "vanilla-sugar",
+    name: "Vanilla Rock Sugar",
+    brand: "Vanilla Sugar",
+    originalBrand: "KAYALI",
+    gender: "Women",
+    mainAccords: [
+      "Sweet",
+      "Gourmand",
+      "Warm Spicy",
+      "Amber",
+      "Creamy",
+      "Woody",
+    ],
+    fragranceProfile: "Oriental Gourmand",
+    bestTime: "Evening/Night",
+    mainSeasons: ["Fall", "Winter", "Early Spring"],
+
+    sillage: "Very Strong",
+    longevity: "8-10 hours",
+    topNotes: ["Vanilla Bean", "Caramelized Sugar", "Bergamot"],
+    middleNotes: ["Tonka Bean", "Amberwood", "Jasmine"],
+    baseNotes: ["Sandalwood", "Benzoin", "Musk", "Patchouli"],
+    description:
+      "An indulgent vanilla-forward gourmand blending caramelized sugar with creamy woods for a captivating evening aura inspired by KAYALI Vanilla Rock Sugar.",
+    sizes: standardSizes,
+  },
+  {
     id: "red-tobacco",
     name: "Red Tobacco",
     brand: "Red Tobacco Flame",

--- a/mixer-final-100-main/client/data/perfumes.ts
+++ b/mixer-final-100-main/client/data/perfumes.ts
@@ -15,6 +15,7 @@ export interface Perfume {
   bestTime: string;
   mainSeasons: string[];
   sillage: string;
+  longevity?: string;
   topNotes: string[];
   middleNotes: string[];
   baseNotes: string[];

--- a/mixer-final-100-main/netlify.toml
+++ b/mixer-final-100-main/netlify.toml
@@ -1,0 +1,22 @@
+# Netlify configuration
+
+[build]
+  command = "pnpm run build:client"
+  publish = "dist/spa"
+  functions = "netlify/functions"
+
+# Bundle Node functions with esbuild (fast, supports TypeScript)
+[functions]
+  node_bundler = "esbuild"
+
+# Proxy API requests to the serverless Express function
+[[redirects]]
+  from = "/api/*"
+  to = "/.netlify/functions/api/:splat"
+  status = 200
+
+# SPA fallback to support React Router on refresh/deep links
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
## Purpose

The user requested to add a new "Vanilla Sugar" perfume inspired by KAYALI's Vanilla Rock Sugar to the collection, and to remove the fragrance list section from the quiz page while adding a buy now link for the new perfume.

## Code changes

- **Added new perfume**: Created "Vanilla Sugar" entry in `perfumes.ts` with complete fragrance profile including oriental gourmand characteristics, evening/night timing, and 8-10 hour longevity
- **Added buy link**: Registered purchase URL for Vanilla Sugar in `perfume-links.ts` 
- **Removed quiz fragrance section**: Eliminated the complete fragrance browsing functionality from Quiz.tsx including filters, sorting, and perfume grid display
- **Added Netlify config**: Included deployment configuration for hosting setup
- **Updated interface**: Added optional `longevity` field to Perfume interface

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2d4a7a79f7f049319c8abbc59b2b9a2e/zenith-works)

👀 [Preview Link](https://2d4a7a79f7f049319c8abbc59b2b9a2e-zenith-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2d4a7a79f7f049319c8abbc59b2b9a2e</projectId>-->
<!--<branchName>zenith-works</branchName>-->